### PR TITLE
refactor: remove no-longer-needed logic from sitemap generation

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -4,12 +4,5 @@ import { MetadataRoute } from 'next';
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const sitemap = await getSitemap();
 
-  if (!sitemap) {
-    return [];
-  }
-
-  return sitemap.map((loc) => ({
-    url: loc.url,
-    lastModified: loc.lastModified ? new Date(loc.lastModified) : undefined,
-  }));
+  return sitemap ?? [];
 }


### PR DESCRIPTION
The sitemap query was previously updated to ensure `lastModified` is always a `string` type, so this logic is no longer necessary.